### PR TITLE
Fix django-filters version.

### DIFF
--- a/p0sx/settings/base.py
+++ b/p0sx/settings/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = (
     'pos',
     'rest_framework',
     'rest_framework.authtoken',
+    'django_filters',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -69,7 +70,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',)
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 
 ROOT_URLCONF = 'p0sx.urls'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Django==1.11.29
-django-filter==0.14.0
+django-filter==1.1.0
 djangorestframework==3.4.6
 django-extensions==1.7.2
 Werkzeug==0.15.3


### PR DESCRIPTION
As dependabot have upgraded django and DRF, current version of django-filters was throwing 500-error when pulling data from p0sX.

### Status

- [X] Done
- [ ] Work in progress
- [ ] Needs testing from others

### Description


### Checklist

- [ ] The code is linted
- [ ] My changes requires change to the documentation.
- [ ] I have updated the documentation.
- [ ] I have introduced changes to build configuration.


### Minor Changes

- Bumping version of django-filters
