### PR TITLE
Fixes bug in admin-view

### DIFF
--- a/p0sx/pos/admin.py
+++ b/p0sx/pos/admin.py
@@ -52,7 +52,7 @@ class OrderLineInline(admin.TabularInline):
     def has_delete_permission(self, request, obj=None):
         return False
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 


### PR DESCRIPTION
This PR fixes the only bug I've found in the admin-view after the upgrade to Django 3.2. Doc states obj needs to be set after Django >2. 